### PR TITLE
Sync parser fixes from loom and add regression tests

### DIFF
--- a/src/lib/parser/dot_parser.mbt
+++ b/src/lib/parser/dot_parser.mbt
@@ -554,14 +554,7 @@ fn Parser::parse_edge_endpoint_node_ids(self : Parser) -> Array[NodeId]? {
     Some(node_id) => Some([node_id])
     None =>
       match self.parse_subgraph() {
-        Some(subgraph) => {
-          let node_ids = node_ids_in_subgraph(subgraph)
-          if node_ids.is_empty() {
-            None
-          } else {
-            Some(node_ids)
-          }
-        }
+        Some(subgraph) => Some(node_ids_in_subgraph(subgraph))
         None => None
       }
   }
@@ -683,7 +676,14 @@ fn expand_edge_statements(
 ///|
 fn Parser::emit_expanded_statements(self : Parser, statements : Array[Statement]) -> Statement? {
   if statements.is_empty() {
-    return None
+    loop self.current_token {
+      Semicolon => {
+        self.eat(Semicolon) |> ignore
+        continue self.current_token
+      }
+      _ => break
+    }
+    return self.parse_statement()
   }
   for i = statements.length() - 1; i > 0; i = i - 1 {
     self.pending_statements.push(statements[i])
@@ -729,17 +729,13 @@ fn Parser::parse_statement(self : Parser) -> Statement? {
           match self.parse_edge_rhs() {
             Parsed(edge_chain) => {
               let start_nodes = node_ids_in_subgraph(subgraph)
-              if start_nodes.is_empty() {
-                None
-              } else {
-                let attr_list = self.parse_attr_list()
-                let expanded = expand_edge_statements(
-                  start_nodes,
-                  edge_chain,
-                  attr_list,
-                )
-                self.emit_expanded_statements(expanded)
-              }
+              let attr_list = self.parse_attr_list()
+              let expanded = expand_edge_statements(
+                start_nodes,
+                edge_chain,
+                attr_list,
+              )
+              self.emit_expanded_statements(expanded)
             }
             NoEdgeOp => Some(Subgraph(subgraph))
             Malformed => None

--- a/src/lib/parser/dot_parser_test.mbt
+++ b/src/lib/parser/dot_parser_test.mbt
@@ -1017,9 +1017,42 @@ test "parse_dot expands subgraph target operand with multiple nodes" {
 }
 
 ///|
-test "parse_dot rejects edge statement from empty subgraph endpoint" {
+test "parse_dot accepts edge statement from empty subgraph endpoint as no-op" {
   let parsed = parse_dot("digraph { subgraph cluster_0 { } -> b; }")
-  inspect(parsed == None, content="true")
+  match parsed {
+    Some(graph) => inspect(graph.statements.length(), content="0")
+    None => abort("expected parser to accept empty subgraph edge operand")
+  }
+}
+
+///|
+test "parse_dot continues after empty subgraph edge no-op" {
+  let parsed = parse_dot("digraph { subgraph { } -> b; c; }")
+  match parsed {
+    Some(graph) => {
+      inspect(graph.statements.length(), content="1")
+      match graph.statements[0] {
+        NodeStmt(node_id, _) => inspect(node_id.id, content="c")
+        _ => abort("expected node statement after no-op edge")
+      }
+    }
+    None => abort("expected parser to continue after empty subgraph edge")
+  }
+}
+
+///|
+test "parse_dot accepts empty subgraph target operand as no-op" {
+  let parsed = parse_dot("digraph { a -> subgraph { }; b; }")
+  match parsed {
+    Some(graph) => {
+      inspect(graph.statements.length(), content="1")
+      match graph.statements[0] {
+        NodeStmt(node_id, _) => inspect(node_id.id, content="b")
+        _ => abort("expected node statement after no-op edge")
+      }
+    }
+    None => abort("expected parser to accept empty subgraph edge target")
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary\n- sync DOT parser fixes from loom into parent graphviz package\n- add parser regression tests for trailing tokens, slash/comment handling, decimal numbers, subgraph edge operands, and stricter port/edge-rhs validation\n\n## Validation\n- moon test (74 passed)\n- moon info\n\n## Notes\n- safe partial sync only (parser code + tests), no metadata mirror

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced full-file consumption to reject trailing input; improved detection of malformed edge RHS and port errors.
  * Fixed trailing slash/comment hang scenarios.

* **New Features**
  * Support for hash (#) and C++-style (//) comments plus block comments.
  * Numeric literals and dotted identifiers parsed as single tokens.
  * Expanded port and compass-point syntax and automatic expansion of chained edges/subgraph endpoints.
  * More permissive quoting/formatting for node identifiers.

* **Tests**
  * Extensive tests for comments, ports, edges/subgraphs, malformed inputs, and round-tripping formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->