### PR TITLE
refactor: fix v0.9 deprecation warnings

### DIFF
--- a/src/lib/parser/formatter.mbt
+++ b/src/lib/parser/formatter.mbt
@@ -119,14 +119,16 @@ fn format_statement_with_indent(stmt : Statement, indent_level : Int) -> String 
       result
     }
     EdgeStmt(start_node, edges, attr_list) => {
-      let mut result = loop (edges[:], format_node_id(start_node)) {
-        ([], acc) => break acc
-        ([(edge_op, node_id), .. rest], acc) => {
-          let op_str = match edge_op {
-            Directed => " -> "
-            Undirected => " -- "
+      let mut result = for rest = edges[:], acc = format_node_id(start_node) {
+        match rest {
+          [] => break acc
+          [(edge_op, node_id), .. rest2] => {
+            let op_str = match edge_op {
+              Directed => " -> "
+              Undirected => " -- "
+            }
+            continue rest2, acc + op_str + format_node_id(node_id)
           }
-          continue (rest, acc + op_str + format_node_id(node_id))
         }
       }
       match attr_list {

--- a/src/lib/parser/lexer.mbt
+++ b/src/lib/parser/lexer.mbt
@@ -61,11 +61,13 @@ fn Lexer::skip_comment(self : Lexer) -> Bool {
   match self.current_char {
     Some('#') => {
       // Hash comment: consume until newline or EOF
-      loop self.current_char {
-        Some('\n') | None => break
-        _ => {
-          self.advance()
-          continue self.current_char
+      for ch = self.current_char {
+        match ch {
+          Some('\n') | None => break
+          _ => {
+            self.advance()
+            continue self.current_char
+          }
         }
       }
       true
@@ -77,11 +79,13 @@ fn Lexer::skip_comment(self : Lexer) -> Bool {
           self.advance()
           self.advance()
           // Single line comment
-          loop self.current_char {
-            Some('\n') | None => break
-            _ => {
-              self.advance()
-              continue self.current_char
+          for ch = self.current_char {
+            match ch {
+              Some('\n') | None => break
+              _ => {
+                self.advance()
+                continue self.current_char
+              }
             }
           }
           true
@@ -92,22 +96,24 @@ fn Lexer::skip_comment(self : Lexer) -> Bool {
           self.advance()
           let mut closed = false
           // Multi-line comment
-          loop self.current_char {
-            None => break
-            Some('*') => {
-              self.advance()
-              match self.current_char {
-                Some('/') => {
-                  self.advance()
-                  closed = true
-                  break
+          for ch = self.current_char {
+            match ch {
+              None => break
+              Some('*') => {
+                self.advance()
+                match self.current_char {
+                  Some('/') => {
+                    self.advance()
+                    closed = true
+                    break
+                  }
+                  _ => continue self.current_char
                 }
-                _ => continue self.current_char
               }
-            }
-            _ => {
-              self.advance()
-              continue self.current_char
+              _ => {
+                self.advance()
+                continue self.current_char
+              }
             }
           }
           closed
@@ -121,13 +127,15 @@ fn Lexer::skip_comment(self : Lexer) -> Bool {
 ///|
 fn Lexer::read_identifier(self : Lexer) -> String {
   let buf = StringBuilder::new()
-  loop self.current_char {
-    Some(c) if c.is_numeric() || c.is_ascii_alphabetic() || c == '_' => {
-      buf.write_char(c)
-      self.advance()
-      continue self.current_char
+  for ch = self.current_char {
+    match ch {
+      Some(c) if c.is_numeric() || c.is_ascii_alphabetic() || c == '_' => {
+        buf.write_char(c)
+        self.advance()
+        continue self.current_char
+      }
+      _ => break
     }
-    _ => break
   }
   buf.to_string()
 }
@@ -142,19 +150,21 @@ fn Lexer::read_dotted_identifier(self : Lexer) -> String {
 fn Lexer::read_number(self : Lexer) -> String {
   let buf = StringBuilder::new()
   let mut has_dot = false
-  loop self.current_char {
-    Some(c) if c.is_numeric() => {
-      buf.write_char(c)
-      self.advance()
-      continue self.current_char
+  for ch = self.current_char {
+    match ch {
+      Some(c) if c.is_numeric() => {
+        buf.write_char(c)
+        self.advance()
+        continue self.current_char
+      }
+      Some('.') if !has_dot => {
+        buf.write_char('.')
+        has_dot = true
+        self.advance()
+        continue self.current_char
+      }
+      _ => break
     }
-    Some('.') if !has_dot => {
-      buf.write_char('.')
-      has_dot = true
-      self.advance()
-      continue self.current_char
-    }
-    _ => break
   }
   buf.to_string()
 }
@@ -164,30 +174,32 @@ fn Lexer::read_quoted_string(self : Lexer) -> String {
   let quote_char = self.current_char.unwrap()
   self.advance() // Skip opening quote
   let buf = StringBuilder::new()
-  loop self.current_char {
-    Some(c) if c == quote_char => break // End of string
-    Some('\\') => {
-      self.advance() // Skip escape character
-      match self.current_char {
-        Some(escaped_char) => {
-          match escaped_char {
-            'n' => buf.write_char('\n')
-            't' => buf.write_char('\t')
-            'r' => buf.write_char('\r')
-            _ => buf.write_char(escaped_char)
+  for ch = self.current_char {
+    match ch {
+      Some(c) if c == quote_char => break // End of string
+      Some('\\') => {
+        self.advance() // Skip escape character
+        match self.current_char {
+          Some(escaped_char) => {
+            match escaped_char {
+              'n' => buf.write_char('\n')
+              't' => buf.write_char('\t')
+              'r' => buf.write_char('\r')
+              _ => buf.write_char(escaped_char)
+            }
+            self.advance()
+            continue self.current_char
           }
-          self.advance()
-          continue self.current_char
+          None => break // Unexpected end of input
         }
-        None => break // Unexpected end of input
       }
+      Some(c) => {
+        buf.write_char(c)
+        self.advance()
+        continue self.current_char
+      }
+      None => break // End of input
     }
-    Some(c) => {
-      buf.write_char(c)
-      self.advance()
-      continue self.current_char
-    }
-    None => break // End of input
   }
 
   // Skip closing quote

--- a/src/lib/parser/parser.mbt
+++ b/src/lib/parser/parser.mbt
@@ -354,12 +354,14 @@ fn Parser::emit_expanded_statements(
   statements : Array[Statement],
 ) -> Statement? {
   if statements.is_empty() {
-    loop self.current_token {
-      Semicolon => {
-        self.eat(Semicolon) |> ignore
-        continue self.current_token
+    for tok = self.current_token {
+      match tok {
+        Semicolon => {
+          self.eat(Semicolon) |> ignore
+          continue self.current_token
+        }
+        _ => break
       }
-      _ => break
     }
     return self.parse_statement()
   }
@@ -506,12 +508,14 @@ fn Parser::parse_stmt_list(self : Parser) -> Array[Statement] {
   let statements = []
   while true {
     // Skip leading/repeated semicolons
-    loop self.current_token {
-      Semicolon => {
-        self.eat(Semicolon) |> ignore
-        continue self.current_token
+    for tok = self.current_token {
+      match tok {
+        Semicolon => {
+          self.eat(Semicolon) |> ignore
+          continue self.current_token
+        }
+        _ => break
       }
-      _ => break
     }
     match self.parse_statement() {
       Some(stmt) => statements.push(stmt)
@@ -524,19 +528,21 @@ fn Parser::parse_stmt_list(self : Parser) -> Array[Statement] {
 ///|
 fn Parser::parse_subgraph(self : Parser) -> Subgraph? {
   // Optional "subgraph" keyword
-  let id = loop (self.current_token, None) {
-    (Subgraph, id) => {
-      self.eat(Subgraph) |> ignore
-      // Optional ID after subgraph
-      match self.current_token {
-        ID(sub_id) => {
-          self.eat(ID("")) |> ignore
-          continue (self.current_token, Some(sub_id))
+  let id = for tok = self.current_token, id = (None : String?) {
+    match tok {
+      Subgraph => {
+        self.eat(Subgraph) |> ignore
+        // Optional ID after subgraph
+        match self.current_token {
+          ID(sub_id) => {
+            self.eat(ID("")) |> ignore
+            continue self.current_token, Some(sub_id)
+          }
+          _ => continue self.current_token, id
         }
-        _ => continue (self.current_token, id)
       }
+      _ => break id
     }
-    (_, id) => break id
   }
   if !self.eat(LeftBrace) {
     return None


### PR DESCRIPTION
## Summary
- Migrate deprecated `loop` syntax to `for` loops in lexer, parser, and formatter

## Test plan
- [x] `moon check --deny-warn` — 0 errors
- [x] `moon test` — 112 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)