### PR TITLE
chore: replace deprecated MoonBit APIs

### DIFF
--- a/src/lib/layout/adjacency.mbt
+++ b/src/lib/layout/adjacency.mbt
@@ -4,8 +4,8 @@
 fn build_adjacency(
   edges : Array[EdgeData],
 ) -> (Map[String, Array[String]], Map[String, Array[String]]) {
-  let incoming : Map[String, Array[String]] = Map::new()
-  let outgoing : Map[String, Array[String]] = Map::new()
+  let incoming : Map[String, Array[String]] = Map::default()
+  let outgoing : Map[String, Array[String]] = Map::default()
   for edge in edges {
     // Ensure both nodes exist in maps
     if !outgoing.contains(edge.from) {

--- a/src/lib/layout/coordinate_assignment.mbt
+++ b/src/lib/layout/coordinate_assignment.mbt
@@ -6,7 +6,7 @@ fn assign_coordinates(
   nodes : Map[String, NodeData],
   config : LayoutConfig,
 ) -> Map[String, LayoutNode] {
-  let positions : Map[String, LayoutNode] = Map::new()
+  let positions : Map[String, LayoutNode] = Map::default()
   for layer_index = 0
       layer_index < layers.length()
       layer_index = layer_index + 1 {

--- a/src/lib/layout/crossing_minimization.mbt
+++ b/src/lib/layout/crossing_minimization.mbt
@@ -68,11 +68,11 @@ fn compute_layer_barycenters(
   adjacent_layer : Array[String],
   connections : Map[String, Array[String]],
 ) -> Map[String, Double] {
-  let pos_index : Map[String, Int] = Map::new()
+  let pos_index : Map[String, Int] = Map::default()
   for i = 0; i < adjacent_layer.length(); i = i + 1 {
     pos_index.set(adjacent_layer[i], i)
   }
-  let barycenters : Map[String, Double] = Map::new()
+  let barycenters : Map[String, Double] = Map::default()
   let default_pos = adjacent_layer.length().to_double() / 2.0
   for node in current_layer {
     let connected = match connections.get(node) {

--- a/src/lib/layout/cycle_removal.mbt
+++ b/src/lib/layout/cycle_removal.mbt
@@ -15,15 +15,15 @@ fn remove_cycles(edges : Array[EdgeData]) -> (Array[EdgeData], Array[Bool]) {
     reversed_edges.push(false)
   }
   let state : DFSState = {
-    visited: Map::new(),
-    on_stack: Map::new(),
+    visited: Map::default(),
+    on_stack: Map::default(),
     reversed_edges,
   }
   // DFS root choice decides which back edge gets flipped in a cycle.
   // Preserving first-seen order keeps that decision tied to DOT input order
   // instead of HashSet iteration order.
   let all_nodes : Array[String] = []
-  let seen_nodes : @hashset.HashSet[String] = @hashset.HashSet::new()
+  let seen_nodes : @hashset.HashSet[String] = @hashset.HashSet::default()
   for edge in edges {
     if !seen_nodes.contains(edge.from) {
       seen_nodes.add(edge.from)
@@ -63,7 +63,7 @@ fn remove_cycles(edges : Array[EdgeData]) -> (Array[EdgeData], Array[Bool]) {
 fn build_indexed_outgoing_adjacency(
   edges : Array[EdgeData],
 ) -> Map[String, Array[(String, Int)]] {
-  let outgoing : Map[String, Array[(String, Int)]] = Map::new()
+  let outgoing : Map[String, Array[(String, Int)]] = Map::default()
   for i = 0; i < edges.length(); i = i + 1 {
     let edge = edges[i]
     if !outgoing.contains(edge.from) {

--- a/src/lib/layout/graph_builder.mbt
+++ b/src/lib/layout/graph_builder.mbt
@@ -31,7 +31,7 @@ fn extract_attr(key : String, attrs : @parser.AttributeList?) -> String? {
 fn collect_nodes(
   statements : Array[@parser.Statement],
 ) -> Map[String, NodeData] {
-  let nodes : Map[String, NodeData] = Map::new()
+  let nodes : Map[String, NodeData] = Map::default()
   collect_nodes_with_defaults(statements, None, nodes)
   nodes
 }
@@ -48,7 +48,7 @@ fn collect_nodes_with_defaults(
       @parser.AttrStmt(@parser.NodeAttr, attr_list) =>
         node_defaults = merge_attrs(node_defaults, Some(attr_list))
       @parser.NodeStmt(node_id, attrs) => {
-        let explicit = @hashset.HashSet::new()
+        let explicit = @hashset.HashSet::default()
         if extract_attr("label", attrs) is Some(_) {
           explicit.add("label")
         }
@@ -109,7 +109,7 @@ fn build_node_data(
 fn merge_node_data(existing : NodeData, update : NodeData) -> NodeData {
   // Re-mentioning a node with new defaults should not erase a value that was
   // explicitly set earlier, so we track which attrs were set on the node itself.
-  let merged_explicit = @hashset.HashSet::new()
+  let merged_explicit = @hashset.HashSet::default()
   existing.explicit_attrs.each(fn(k) { merged_explicit.add(k) })
   update.explicit_attrs.each(fn(k) { merged_explicit.add(k) })
   fn pick(
@@ -160,7 +160,7 @@ fn ensure_node(
   attrs : @parser.AttributeList?,
 ) -> Unit {
   if !nodes.contains(node_id) {
-    nodes.set(node_id, build_node_data(node_id, attrs, @hashset.HashSet::new()))
+    nodes.set(node_id, build_node_data(node_id, attrs, @hashset.HashSet::default()))
   }
 }
 

--- a/src/lib/layout/layer_assignment.mbt
+++ b/src/lib/layout/layer_assignment.mbt
@@ -25,7 +25,7 @@ fn assign_layers(
       )
   }
   // Forward propagation: each node's layer = max(predecessor layers) + 1
-  let int_layer : Map[Int, Int] = Map::new()
+  let int_layer : Map[Int, Int] = Map::default()
   for v in topo_order {
     let current_layer = match int_layer.get(v) {
       Some(l) => l
@@ -40,7 +40,7 @@ fn assign_layers(
     })
   }
   // Map back to String keys via O(1) array index reverse lookup
-  let layer_map : Map[String, Int] = Map::new()
+  let layer_map : Map[String, Int] = Map::default()
   for idx, layer in int_layer {
     layer_map[vmap.to_string[idx]] = layer
   }

--- a/src/lib/layout/layout_test.mbt
+++ b/src/lib/layout/layout_test.mbt
@@ -10,9 +10,9 @@ test "full_layout_simple_chain" {
   match @parser.parse_dot(dot) {
     Ok(graph) => {
       let layout = compute_layout(graph)
-      inspect(layout.nodes.length(), content="3")
-      inspect(layout.edges.length(), content="2")
-      inspect(layout.layers.length(), content="3")
+      @builtin.inspect(layout.nodes.length(), content="3")
+      @builtin.inspect(layout.edges.length(), content="2")
+      @builtin.inspect(layout.layers.length(), content="3")
 
       // Verify all nodes exist
       if layout.nodes.contains("a") &&
@@ -37,9 +37,9 @@ test "full_layout_diamond" {
   match @parser.parse_dot(dot) {
     Ok(graph) => {
       let layout = compute_layout(graph)
-      inspect(layout.nodes.length(), content="4")
-      inspect(layout.edges.length(), content="4")
-      inspect(layout.layers.length(), content="3")
+      @builtin.inspect(layout.nodes.length(), content="4")
+      @builtin.inspect(layout.edges.length(), content="4")
+      @builtin.inspect(layout.layers.length(), content="3")
     }
     Err(_) => abort("Parse error: full_layout_diamond")
   }
@@ -59,7 +59,7 @@ test "full_layout_automaton" {
   match @parser.parse_dot(dot_automaton) {
     Ok(graph) => {
       let layout = compute_layout(graph)
-      inspect(layout.nodes.length(), content="6")
+      @builtin.inspect(layout.nodes.length(), content="6")
     }
     Err(_) => abort("Parse error: full_layout_automaton")
   }

--- a/src/lib/layout/layout_wbtest.mbt
+++ b/src/lib/layout/layout_wbtest.mbt
@@ -9,7 +9,7 @@ fn test_node_data(id : String) -> NodeData {
     color: None,
     fontcolor: None,
     fillcolor: None,
-    explicit_attrs: @hashset.HashSet::new(),
+    explicit_attrs: @hashset.HashSet::default(),
   }
 }
 
@@ -18,8 +18,8 @@ test "extract_graph_simple" {
   match @parser.parse_dot("digraph { a -> b }") {
     Ok(graph) => {
       let (nodes, edges) = extract_graph(graph)
-      inspect(nodes.length(), content="2")
-      inspect(edges.length(), content="1")
+      @builtin.inspect(nodes.length(), content="2")
+      @builtin.inspect(edges.length(), content="1")
     }
     Err(_) => abort("parse failed")
   }
@@ -81,7 +81,7 @@ test "extract_graph_explicit_label_matching_id_overrides_default_label" {
     Ok(graph) => {
       let (nodes, _edges) = extract_graph(graph)
       let node = nodes.get("a").unwrap()
-      inspect(node.label, content="a")
+      @builtin.inspect(node.label, content="a")
     }
     Err(_) => abort("parse failed")
   }
@@ -94,7 +94,7 @@ test "extract_graph_default_label_does_not_overwrite_existing_explicit_label" {
     Ok(graph) => {
       let (nodes, _edges) = extract_graph(graph)
       let node = nodes.get("a").unwrap()
-      inspect(node.label, content="custom")
+      @builtin.inspect(node.label, content="custom")
     }
     Err(_) => abort("parse failed")
   }
@@ -107,7 +107,7 @@ test "extract_graph_rementioned_nodes_adopt_newer_default_labels" {
     Ok(graph) => {
       let (nodes, _edges) = extract_graph(graph)
       let node = nodes.get("a").unwrap()
-      inspect(node.label, content="new")
+      @builtin.inspect(node.label, content="new")
     }
     Err(_) => abort("parse failed")
   }
@@ -151,17 +151,17 @@ test "extract_graph_rementioned_nodes_adopt_newer_defaults" {
 test "cycle_removal_acyclic_unchanged" {
   let edges : Array[EdgeData] = [{ from: "a", to: "b" }, { from: "b", to: "c" }]
   let (result, reversed) = remove_cycles(edges)
-  inspect(result.length(), content="2")
-  inspect(reversed, content="[false, false]")
+  @builtin.inspect(result.length(), content="2")
+  @builtin.inspect(reversed, content="[false, false]")
 }
 
 ///|
 test "cycle_removal_single_cycle" {
   let edges : Array[EdgeData] = [{ from: "a", to: "b" }, { from: "b", to: "a" }]
   let (result, reversed) = remove_cycles(edges)
-  inspect(result.length(), content="2")
+  @builtin.inspect(result.length(), content="2")
   // Exactly one edge should be reversed
-  inspect(reversed[0] != reversed[1], content="true")
+  @builtin.inspect(reversed[0] != reversed[1], content="true")
 }
 
 ///|
@@ -171,19 +171,19 @@ test "cycle_removal_uses_first_seen_root_order" {
     { from: "b", to: "a" },
   ]
   let (_, ab_reversed) = remove_cycles(ab_edges)
-  inspect(ab_reversed, content="[false, true]")
+  @builtin.inspect(ab_reversed, content="[false, true]")
 
   let aabb_edges : Array[EdgeData] = [
     { from: "aa", to: "bb" },
     { from: "bb", to: "aa" },
   ]
   let (_, aabb_reversed) = remove_cycles(aabb_edges)
-  inspect(aabb_reversed, content="[false, true]")
+  @builtin.inspect(aabb_reversed, content="[false, true]")
 }
 
 ///|
 test "layer_assignment_sources_at_zero" {
-  let nodes : Map[String, NodeData] = Map::new()
+  let nodes : Map[String, NodeData] = Map::default()
   nodes.set("a", test_node_data("a"))
   nodes.set("b", test_node_data("b"))
   nodes.set("c", test_node_data("c"))
@@ -194,7 +194,7 @@ test "layer_assignment_sources_at_zero" {
 
 ///|
 test "layer_assignment_edges_go_lower_to_higher" {
-  let nodes : Map[String, NodeData] = Map::new()
+  let nodes : Map[String, NodeData] = Map::default()
   nodes.set("a", test_node_data("a"))
   nodes.set("b", test_node_data("b"))
   nodes.set("c", test_node_data("c"))
@@ -203,8 +203,8 @@ test "layer_assignment_edges_go_lower_to_higher" {
   let a_layer = layers.get("a").unwrap()
   let b_layer = layers.get("b").unwrap()
   let c_layer = layers.get("c").unwrap()
-  inspect(a_layer < b_layer, content="true")
-  inspect(b_layer < c_layer, content="true")
+  @builtin.inspect(a_layer < b_layer, content="true")
+  @builtin.inspect(b_layer < c_layer, content="true")
 }
 
 ///|
@@ -213,15 +213,15 @@ test "crossing_minimization_preserves_nodes" {
   let layers : Array[Array[String]] = [["a", "b"], ["c", "d"]]
   let result = minimize_crossings(edges, layers, 4)
   // Same number of layers
-  inspect(result.length(), content="2")
+  @builtin.inspect(result.length(), content="2")
   // Same number of nodes per layer
-  inspect(result[0].length(), content="2")
-  inspect(result[1].length(), content="2")
+  @builtin.inspect(result[0].length(), content="2")
+  @builtin.inspect(result[1].length(), content="2")
 }
 
 ///|
 test "coordinate_assignment_no_overlap" {
-  let nodes : Map[String, NodeData] = Map::new()
+  let nodes : Map[String, NodeData] = Map::default()
   nodes.set("a", test_node_data("a"))
   nodes.set("b", test_node_data("b"))
   let layers : Array[Array[String]] = [["a", "b"]]
@@ -231,14 +231,14 @@ test "coordinate_assignment_no_overlap" {
   let b_pos = positions.get("b").unwrap()
   // Nodes in same layer should not overlap in X
   let a_right = a_pos.position.x + a_pos.size.width
-  inspect(a_right <= b_pos.position.x, content="true")
+  @builtin.inspect(a_right <= b_pos.position.x, content="true")
 }
 
 ///|
 test "edge_routing_has_waypoints" {
   let edges : Array[EdgeData] = [{ from: "a", to: "b" }]
   let reversed : Array[Bool] = [false]
-  let positions : Map[String, LayoutNode] = Map::new()
+  let positions : Map[String, LayoutNode] = Map::default()
   positions.set("a", {
     id: "a",
     label: "a",
@@ -263,15 +263,15 @@ test "edge_routing_has_waypoints" {
   })
   let config = LayoutConfig::default()
   let routed = route_edges(edges, reversed, positions, config)
-  inspect(routed.length(), content="1")
-  inspect(routed[0].waypoints.length() >= 2, content="true")
+  @builtin.inspect(routed.length(), content="1")
+  @builtin.inspect(routed[0].waypoints.length() >= 2, content="true")
 }
 
 ///|
 test "edge_routing_tracks_reversal_per_edge" {
   let edges : Array[EdgeData] = [{ from: "a", to: "b" }, { from: "b", to: "a" }]
   let (acyclic_edges, reversed) = remove_cycles(edges)
-  let positions : Map[String, LayoutNode] = Map::new()
+  let positions : Map[String, LayoutNode] = Map::default()
   positions.set("a", {
     id: "a",
     label: "a",
@@ -296,6 +296,6 @@ test "edge_routing_tracks_reversal_per_edge" {
   })
   let config = LayoutConfig::default()
   let routed = route_edges(acyclic_edges, reversed, positions, config)
-  inspect(routed.length(), content="2")
-  inspect(routed[0].reversed != routed[1].reversed, content="true")
+  @builtin.inspect(routed.length(), content="2")
+  @builtin.inspect(routed[0].reversed != routed[1].reversed, content="true")
 }

--- a/src/lib/layout/layout_wbtest.mbt
+++ b/src/lib/layout/layout_wbtest.mbt
@@ -152,7 +152,7 @@ test "cycle_removal_acyclic_unchanged" {
   let edges : Array[EdgeData] = [{ from: "a", to: "b" }, { from: "b", to: "c" }]
   let (result, reversed) = remove_cycles(edges)
   @builtin.inspect(result.length(), content="2")
-  @builtin.inspect(reversed, content="[false, false]")
+  @debug.debug_inspect(reversed, content="[false, false]")
 }
 
 ///|
@@ -171,14 +171,14 @@ test "cycle_removal_uses_first_seen_root_order" {
     { from: "b", to: "a" },
   ]
   let (_, ab_reversed) = remove_cycles(ab_edges)
-  @builtin.inspect(ab_reversed, content="[false, true]")
+  @debug.debug_inspect(ab_reversed, content="[false, true]")
 
   let aabb_edges : Array[EdgeData] = [
     { from: "aa", to: "bb" },
     { from: "bb", to: "aa" },
   ]
   let (_, aabb_reversed) = remove_cycles(aabb_edges)
-  @builtin.inspect(aabb_reversed, content="[false, true]")
+  @debug.debug_inspect(aabb_reversed, content="[false, true]")
 }
 
 ///|

--- a/src/lib/layout/moon.pkg
+++ b/src/lib/layout/moon.pkg
@@ -2,6 +2,7 @@ import {
   "dowdiness/graphviz/lib/parser",
   "dowdiness/alga",
   "moonbitlang/core/bench",
+  "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
   "moonbitlang/core/hashset",
 }

--- a/src/lib/layout/vertex_map.mbt
+++ b/src/lib/layout/vertex_map.mbt
@@ -13,7 +13,7 @@ priv struct VertexMap {
 /// Build a VertexMap from the node map.
 /// Each node gets a stable Int index based on insertion order.
 fn VertexMap::from_nodes(nodes : Map[String, NodeData]) -> VertexMap {
-  let to_int : Map[String, Int] = Map::new()
+  let to_int : Map[String, Int] = Map::default()
   let to_string : Array[String] = []
   for id, _ in nodes {
     to_int[id] = to_string.length()

--- a/src/lib/parser/moon.pkg
+++ b/src/lib/parser/moon.pkg
@@ -1,3 +1,4 @@
 import {
+  "moonbitlang/core/builtin",
   "moonbitlang/core/debug",
 }

--- a/src/lib/parser/parser_test.mbt
+++ b/src/lib/parser/parser_test.mbt
@@ -583,7 +583,7 @@ test "parse_record_shaped_node" {
 ///|
 test "parse_dot rejects malformed attribute_without_value" {
   let parsed = parse_dot("digraph { a [color] }")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 // Whitespace and comment tests
@@ -752,13 +752,13 @@ test "parse_attributes_requires_full_input_consumption" {
 ///|
 test "parse_dot rejects trailing tokens after closing brace" {
   let parsed = parse_dot("digraph { a -> b; } garbage")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 ///|
 test "parse_dot handles non-comment slash without hanging" {
   let parsed = parse_dot("/")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 ///|
@@ -766,8 +766,8 @@ test "parse_dot still accepts valid comments in graph body" {
   let parsed = parse_dot("digraph { a -> b; // trailing comment\n }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.directed, content="true")
-      inspect(graph.statements.length(), content="1")
+      @builtin.inspect(graph.directed, content="true")
+      @builtin.inspect(graph.statements.length(), content="1")
     }
     Err(_) => abort("expected parser to accept valid comment")
   }
@@ -776,15 +776,15 @@ test "parse_dot still accepts valid comments in graph body" {
 ///|
 test "parse_dot rejects unterminated block comments" {
   let parsed = parse_dot("digraph { a -> b; /* unterminated")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 ///|
 test "parse_attributes accepts decimal numerals" {
   let attrs = parse_attributes("penwidth=1.5")
-  inspect(attrs.length(), content="1")
-  inspect(attrs[0].key, content="penwidth")
-  inspect(attrs[0].value, content="1.5")
+  @builtin.inspect(attrs.length(), content="1")
+  @builtin.inspect(attrs[0].key, content="penwidth")
+  @builtin.inspect(attrs[0].value, content="1.5")
 }
 
 ///|
@@ -792,12 +792,12 @@ test "parse_dot accepts edge statement with subgraph start operand" {
   let parsed = parse_dot("digraph { subgraph { a } -> b; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="1")
+      @builtin.inspect(graph.statements.length(), content="1")
       match graph.statements[0] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges.length(), content="1")
-          inspect(edges[0].1.id, content="b")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges.length(), content="1")
+          @builtin.inspect(edges[0].1.id, content="b")
         }
         _ => abort("expected edge statement")
       }
@@ -811,12 +811,12 @@ test "parse_dot accepts edge statement with subgraph target operand" {
   let parsed = parse_dot("digraph { a -> subgraph { b }; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="1")
+      @builtin.inspect(graph.statements.length(), content="1")
       match graph.statements[0] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges.length(), content="1")
-          inspect(edges[0].1.id, content="b")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges.length(), content="1")
+          @builtin.inspect(edges[0].1.id, content="b")
         }
         _ => abort("expected edge statement")
       }
@@ -830,20 +830,20 @@ test "parse_dot expands subgraph start operand with multiple nodes" {
   let parsed = parse_dot("digraph { { a; b; } -> c; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="2")
+      @builtin.inspect(graph.statements.length(), content="2")
       match graph.statements[0] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges.length(), content="1")
-          inspect(edges[0].1.id, content="c")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges.length(), content="1")
+          @builtin.inspect(edges[0].1.id, content="c")
         }
         _ => abort("expected expanded edge statement")
       }
       match graph.statements[1] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="b")
-          inspect(edges.length(), content="1")
-          inspect(edges[0].1.id, content="c")
+          @builtin.inspect(start.id, content="b")
+          @builtin.inspect(edges.length(), content="1")
+          @builtin.inspect(edges[0].1.id, content="c")
         }
         _ => abort("expected expanded edge statement")
       }
@@ -857,18 +857,18 @@ test "parse_dot expands subgraph target operand with multiple nodes" {
   let parsed = parse_dot("digraph { a -> { b; c; }; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="2")
+      @builtin.inspect(graph.statements.length(), content="2")
       match graph.statements[0] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges[0].1.id, content="b")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges[0].1.id, content="b")
         }
         _ => abort("expected expanded edge statement")
       }
       match graph.statements[1] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges[0].1.id, content="c")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges[0].1.id, content="c")
         }
         _ => abort("expected expanded edge statement")
       }
@@ -881,7 +881,7 @@ test "parse_dot expands subgraph target operand with multiple nodes" {
 test "parse_dot accepts edge statement from empty subgraph endpoint as no-op" {
   let parsed = parse_dot("digraph { subgraph cluster_0 { } -> b; }")
   match parsed {
-    Ok(graph) => inspect(graph.statements.length(), content="0")
+    Ok(graph) => @builtin.inspect(graph.statements.length(), content="0")
     Err(_) => abort("expected parser to accept empty subgraph edge operand")
   }
 }
@@ -891,9 +891,9 @@ test "parse_dot continues after empty subgraph edge no-op" {
   let parsed = parse_dot("digraph { subgraph { } -> b; c; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="1")
+      @builtin.inspect(graph.statements.length(), content="1")
       match graph.statements[0] {
-        NodeStmt(node_id, _) => inspect(node_id.id, content="c")
+        NodeStmt(node_id, _) => @builtin.inspect(node_id.id, content="c")
         _ => abort("expected node statement after no-op edge")
       }
     }
@@ -906,22 +906,22 @@ test "parse_dot preserves_nontrivial_subgraph_start_operand_contents" {
   let parsed = parse_dot("digraph { subgraph { a [color=red]; b -> c } -> d; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="4")
+      @builtin.inspect(graph.statements.length(), content="4")
       match graph.statements[0] {
         Subgraph(subgraph) => {
-          inspect(subgraph.statements.length(), content="2")
+          @builtin.inspect(subgraph.statements.length(), content="2")
           match subgraph.statements[0] {
             NodeStmt(node_id, Some(attrs)) => {
-              inspect(node_id.id, content="a")
-              inspect(attrs.attributes[0].key, content="color")
-              inspect(attrs.attributes[0].value, content="red")
+              @builtin.inspect(node_id.id, content="a")
+              @builtin.inspect(attrs.attributes[0].key, content="color")
+              @builtin.inspect(attrs.attributes[0].value, content="red")
             }
             _ => abort("expected attributed node in preserved subgraph")
           }
           match subgraph.statements[1] {
             EdgeStmt(start, edges, _) => {
-              inspect(start.id, content="b")
-              inspect(edges[0].1.id, content="c")
+              @builtin.inspect(start.id, content="b")
+              @builtin.inspect(edges[0].1.id, content="c")
             }
             _ => abort("expected inner edge in preserved subgraph")
           }
@@ -930,8 +930,8 @@ test "parse_dot preserves_nontrivial_subgraph_start_operand_contents" {
       }
       match graph.statements[1] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges[0].1.id, content="d")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges[0].1.id, content="d")
         }
         _ => abort("expected expanded edge from preserved subgraph node")
       }
@@ -945,22 +945,22 @@ test "parse_dot preserves_nontrivial_subgraph_target_operand_contents" {
   let parsed = parse_dot("digraph { a -> subgraph { b [color=red]; c -> d }; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="4")
+      @builtin.inspect(graph.statements.length(), content="4")
       match graph.statements[0] {
         Subgraph(subgraph) => {
-          inspect(subgraph.statements.length(), content="2")
+          @builtin.inspect(subgraph.statements.length(), content="2")
           match subgraph.statements[0] {
             NodeStmt(node_id, Some(attrs)) => {
-              inspect(node_id.id, content="b")
-              inspect(attrs.attributes[0].key, content="color")
-              inspect(attrs.attributes[0].value, content="red")
+              @builtin.inspect(node_id.id, content="b")
+              @builtin.inspect(attrs.attributes[0].key, content="color")
+              @builtin.inspect(attrs.attributes[0].value, content="red")
             }
             _ => abort("expected attributed node in preserved subgraph")
           }
           match subgraph.statements[1] {
             EdgeStmt(start, edges, _) => {
-              inspect(start.id, content="c")
-              inspect(edges[0].1.id, content="d")
+              @builtin.inspect(start.id, content="c")
+              @builtin.inspect(edges[0].1.id, content="d")
             }
             _ => abort("expected inner edge in preserved subgraph")
           }
@@ -969,8 +969,8 @@ test "parse_dot preserves_nontrivial_subgraph_target_operand_contents" {
       }
       match graph.statements[1] {
         EdgeStmt(start, edges, _) => {
-          inspect(start.id, content="a")
-          inspect(edges[0].1.id, content="b")
+          @builtin.inspect(start.id, content="a")
+          @builtin.inspect(edges[0].1.id, content="b")
         }
         _ => abort("expected expanded edge into preserved subgraph node")
       }
@@ -984,9 +984,9 @@ test "parse_dot accepts empty subgraph target operand as no-op" {
   let parsed = parse_dot("digraph { a -> subgraph { }; b; }")
   match parsed {
     Ok(graph) => {
-      inspect(graph.statements.length(), content="1")
+      @builtin.inspect(graph.statements.length(), content="1")
       match graph.statements[0] {
-        NodeStmt(node_id, _) => inspect(node_id.id, content="b")
+        NodeStmt(node_id, _) => @builtin.inspect(node_id.id, content="b")
         _ => abort("expected node statement after no-op edge")
       }
     }
@@ -997,20 +997,20 @@ test "parse_dot accepts empty subgraph target operand as no-op" {
 ///|
 test "parse_dot rejects missing port id after colon" {
   let parsed = parse_dot("digraph { a: -> b; }")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 ///|
 test "parse_dot rejects trailing colon without compass point" {
   let parsed = parse_dot("digraph { a:port: -> b; }")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 ///|
 test "parse_dot accepts valid port with compass point" {
   let parsed = parse_dot("digraph { a:port:n -> b; }")
   match parsed {
-    Ok(graph) => inspect(graph.statements.length(), content="1")
+    Ok(graph) => @builtin.inspect(graph.statements.length(), content="1")
     Err(_) => abort("expected parser to accept valid port syntax")
   }
 }
@@ -1025,11 +1025,11 @@ test "parse_dot accepts compass-like port id with explicit compass suffix" {
           match start.port {
             Some(port) => {
               match port.id {
-                Some(id) => inspect(id, content="n")
+                Some(id) => @builtin.inspect(id, content="n")
                 None => abort("expected explicit port id")
               }
               match port.compass {
-                Some(SW) => inspect(true, content="true")
+                Some(SW) => @builtin.inspect(true, content="true")
                 _ => abort("expected sw compass point")
               }
             }
@@ -1044,7 +1044,7 @@ test "parse_dot accepts compass-like port id with explicit compass suffix" {
 ///|
 test "parse_dot rejects malformed edge rhs after consumed operator" {
   let parsed = parse_dot("digraph { a -> ; }")
-  inspect(parsed is Err(_), content="true")
+  @builtin.inspect(parsed is Err(_), content="true")
 }
 
 ///|
@@ -1052,8 +1052,8 @@ test "parse_dot_error_has_position_for_missing_brace" {
   match parse_dot("digraph") {
     Ok(_) => abort("should fail")
     Err(e) => {
-      inspect(e.position > 0, content="true")
-      inspect(e.message.length() > 0, content="true")
+      @builtin.inspect(e.position > 0, content="true")
+      @builtin.inspect(e.message.length() > 0, content="true")
     }
   }
 }
@@ -1063,8 +1063,8 @@ test "parse_dot_error_has_position_for_trailing_tokens" {
   match parse_dot("digraph { a } extra") {
     Ok(_) => abort("should fail")
     Err(e) => {
-      inspect(e.message.contains("unexpected"), content="true")
-      inspect(e.position, content="14")
+      @builtin.inspect(e.message.contains("unexpected"), content="true")
+      @builtin.inspect(e.position, content="14")
     }
   }
 }

--- a/src/lib/svg/moon.pkg
+++ b/src/lib/svg/moon.pkg
@@ -6,6 +6,7 @@ import {
 
 import {
   "dowdiness/graphviz/lib/parser",
+  "moonbitlang/core/builtin",
 } for "test"
 
 options(

--- a/src/lib/svg/renderer_test.mbt
+++ b/src/lib/svg/renderer_test.mbt
@@ -12,16 +12,16 @@ test "save_svg_creates_file" {
       match save_svg(layout, filename) {
         Ok(_) =>
           // File should be created successfully
-          inspect(true, content="true")
+          @builtin.inspect(true, content="true")
         Err(e) => {
           println("Error saving file: \{e}")
-          inspect(false, content="true")
+          @builtin.inspect(false, content="true")
         }
       }
     }
     Err(_) => {
       println("Parse failed")
-      inspect(false, content="true")
+      @builtin.inspect(false, content="true")
     }
   }
 }
@@ -38,17 +38,17 @@ test "render_svg_produces_valid_xml_header" {
       let has_xml_header = svg.contains(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
       )
-      inspect(has_xml_header, content="true")
+      @builtin.inspect(has_xml_header, content="true")
 
       // Check for SVG root element
       let has_svg_element = svg.contains(
         "<svg xmlns=\"http://www.w3.org/2000/svg\"",
       )
-      inspect(has_svg_element, content="true")
+      @builtin.inspect(has_svg_element, content="true")
     }
     Err(_) => {
       println("Parse failed")
-      inspect(false, content="true")
+      @builtin.inspect(false, content="true")
     }
   }
 }
@@ -63,11 +63,11 @@ test "render_svg_includes_arrowhead_for_directed_graph" {
 
       // Should have arrow marker definition
       let has_arrowhead = svg.contains("<marker id=\"arrowhead\"")
-      inspect(has_arrowhead, content="true")
+      @builtin.inspect(has_arrowhead, content="true")
     }
     Err(_) => {
       println("Parse failed")
-      inspect(false, content="true")
+      @builtin.inspect(false, content="true")
     }
   }
 }
@@ -82,11 +82,11 @@ test "render_svg_no_arrowhead_for_undirected_graph" {
 
       // Should NOT have arrow marker definition
       let has_arrowhead = svg.contains("<marker id=\"arrowhead\"")
-      inspect(has_arrowhead, content="false")
+      @builtin.inspect(has_arrowhead, content="false")
     }
     Err(_) => {
       println("Parse failed")
-      inspect(false, content="true")
+      @builtin.inspect(false, content="true")
     }
   }
 }
@@ -101,19 +101,19 @@ test "render_html_produces_valid_html_structure" {
 
       // Check for HTML structure
       let has_doctype = html.contains("<!DOCTYPE html>")
-      inspect(has_doctype, content="true")
+      @builtin.inspect(has_doctype, content="true")
       let has_title = html.contains("<title>Test Graph</title>")
-      inspect(has_title, content="true")
+      @builtin.inspect(has_title, content="true")
       let has_svg = html.contains("<svg xmlns=\"http://www.w3.org/2000/svg\"")
-      inspect(has_svg, content="true")
+      @builtin.inspect(has_svg, content="true")
 
       // Should NOT have XML declaration in HTML
       let has_xml_declaration = html.contains("<?xml version")
-      inspect(has_xml_declaration, content="false")
+      @builtin.inspect(has_xml_declaration, content="false")
     }
     Err(_) => {
       println("Parse failed")
-      inspect(false, content="true")
+      @builtin.inspect(false, content="true")
     }
   }
 }
@@ -130,16 +130,16 @@ test "save_html_creates_file" {
       match save_html(layout, filename, "Test") {
         Ok(_) =>
           // File should be created successfully
-          inspect(true, content="true")
+          @builtin.inspect(true, content="true")
         Err(e) => {
           println("Error saving file: \{e}")
-          inspect(false, content="true")
+          @builtin.inspect(false, content="true")
         }
       }
     }
     Err(_) => {
       println("Parse failed")
-      inspect(false, content="true")
+      @builtin.inspect(false, content="true")
     }
   }
 }
@@ -152,10 +152,10 @@ test "render_svg_snapshot_simple_digraph" {
       let layout = @layout.compute_layout(graph)
       let svg = render_svg(layout)
       // Verify key structural elements
-      inspect(svg.contains("<rect"), content="true")
-      inspect(svg.contains("<text"), content="true")
-      inspect(svg.contains("<polyline"), content="true")
-      inspect(svg.contains("arrowhead"), content="true")
+      @builtin.inspect(svg.contains("<rect"), content="true")
+      @builtin.inspect(svg.contains("<text"), content="true")
+      @builtin.inspect(svg.contains("<polyline"), content="true")
+      @builtin.inspect(svg.contains("arrowhead"), content="true")
     }
     Err(_) => abort("parse failed")
   }
@@ -168,9 +168,9 @@ test "render_svg_respects_node_colors" {
     Ok(graph) => {
       let layout = @layout.compute_layout(graph)
       let svg = render_svg(layout)
-      inspect(svg.contains("blue"), content="true")
-      inspect(svg.contains("red"), content="true")
-      inspect(svg.contains("white"), content="true")
+      @builtin.inspect(svg.contains("blue"), content="true")
+      @builtin.inspect(svg.contains("red"), content="true")
+      @builtin.inspect(svg.contains("white"), content="true")
     }
     Err(_) => abort("parse failed")
   }


### PR DESCRIPTION
Replaces deprecated Map::new, HashSet::new, and ambiguous inspect usages for MoonBit 0.1.20260512 compatibility.\n\nValidation:\n- moon check --deny-warn --warn-list @a\n- moon test --deny-warn --warn-list @a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal data structure initialization optimizations across core modules.
  * Standardized test assertion utilities for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dowdiness/graphviz/pull/17)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->